### PR TITLE
feat: exported avatar small parts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -126,4 +126,5 @@ export default class ReactNiceAvatar extends Component<NiceAvatarProps> {
   }
 }
 
+export { Face, Hair, Hat, Ear, Eyebrow, Eye, Glasses, Nose, Mouth, Shirt };
 export { genConfig } from "./utils";


### PR DESCRIPTION
If you want to make your own avatar editor, small parts need to be exported, but this was not provided in the library. Therefore, I had to make this export.